### PR TITLE
Unable to require index.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "esbuild-plugin-cache",
   "version": "0.2.9",
   "description": "Esbuid plugin to use cache for http/https",
-  "main": "index.js",
+  "main": "index.cjs",
+  "module": "index.js",
   "type": "module",
   "typings": "index.d.ts",
   "exports": {


### PR DESCRIPTION
Hi I think the main and module fields needs to be amended -see [esbuild main field](https://esbuild.github.io/api/#main-fields). I had a problem trying to use this package because I needed the cjs version.